### PR TITLE
Fixes for 3.3

### DIFF
--- a/src/EventListener/LoadDataContainerListener.php
+++ b/src/EventListener/LoadDataContainerListener.php
@@ -163,7 +163,17 @@ class LoadDataContainerListener
                 // Options
                 $options = StringUtil::deserialize($model->getL10nLabel('options'));
                 if (null !== $options) {
-                    $data['options'] = [];
+                    // Options might already exist so to avoid option to be erased, we will "concatenate" every options 
+                    // from attributes. This should be improved by restrict attributes to their parent feed. 
+                    if (
+                        array_key_exists($row['name'], $GLOBALS['TL_DCA']['tl_wem_portfolio']['fields'])
+                        && array_key_exists('options', $GLOBALS['TL_DCA']['tl_wem_portfolio']['fields'][$row['name']])
+                    ) {
+                        $data['options'] = $GLOBALS['TL_DCA']['tl_wem_portfolio']['fields'][$row['name']]['options'];
+                    } else {
+                        $data['options'] = [];
+                    }
+
                     $blnIsGroup = false;
                     $blnIsChild = true;
                     $key = null;

--- a/src/Model/Portfolio.php
+++ b/src/Model/Portfolio.php
@@ -298,7 +298,10 @@ class Portfolio extends Model
 
                 if ($varAttribute->translatable) {
                     $objL10n = PortfolioFeedAttributeL10n::findItems(['language' => $lang, 'pid' => $varAttribute->id], 1);
-                    $options = StringUtil::deserialize($objL10n->options ?? []);
+
+                    if (null !== $objL10n) {
+                        $options = StringUtil::deserialize($objL10n->options ?? []);
+                    }
                 }
 
                 if ($varAttribute->multiple) {


### PR DESCRIPTION
Two updates: 
* Concat all options from attributes if they already exist
* Do not erase options if there are no translations (so we have a fallback)